### PR TITLE
feat: Gate elisp evaluation behind grid-table-allow-elisp

### DIFF
--- a/docs/ELISP_FORMULA_GUIDE.md
+++ b/docs/ELISP_FORMULA_GUIDE.md
@@ -2,13 +2,13 @@
 
 ## ⚠️ Warning
 
-**Before using this feature, please note that directly executing any Elisp code in a table is a huge security risk. If you open a .grid file containing malicious Elisp formulas, it may damage your system. Please only use this feature on files you fully trust.**
+**Before using this feature, please note that directly executing any Elisp code in a table is a huge security risk. If you open a .grid file containing malicious Elisp formulas, and enable the elisp feature, it may damage your system. Please only use this feature on files you fully trust.**
 
 **I am not responsible for any issues, damages, or bug reports caused by using this feature, and will not handle related issues. Please use this feature at your own risk. And eat your dog food.**
 
 ## Introduction
 
-Grid Table now supports executing Elisp code in cells, which provides infinite possibilities for table calculations. By using the `elisp:` prefix, you can run any Elisp expression in a cell.
+Grid Table now supports executing Elisp code in cells, which provides infinite possibilities for table calculations. By using the `elisp:` prefix, you can run any Elisp expression in a cell. This is only enabled in buffers with the variable `grid-table-allow-elisp` set to a non-nil value.
 
 ## Basic Syntax
 

--- a/grid-table-calc.el
+++ b/grid-table-calc.el
@@ -50,10 +50,13 @@ AST: The Abstract Syntax Tree to evaluate."
   (pcase ast
     ;; Elisp code execution
     (`(ELISP-CODE ,code-str)
-     (let ((cell (lambda (ref) (grid-calc-get-cell-value model ref))))
-       (condition-case err
-           (eval (read code-str))
-         (error (format "Elisp Error: %s" (error-message-string err))))))
+     ;; only if user opted-in to elisp evaluation
+     (if grid-table-allow-elisp
+         (let ((cell (lambda (ref) (grid-calc-get-cell-value model ref))))
+           (condition-case err
+               (eval (read code-str))
+             (error (format "Elisp Error: %s" (error-message-string err)))))
+       (error "Elisp disabled: see `grid-calc-allow-elisp'")))
 
     ;; Number literal
     (`(NUMBER ,value) value)

--- a/grid-table.el
+++ b/grid-table.el
@@ -69,6 +69,13 @@
                  (const :tag "Rule" rule))
   :group 'grid-table)
 
+(defvar-local grid-table-allow-elisp nil
+  "Buffer-local variable to enable elisp evaluation in table cells.
+
+If this is nil, elisp formulas are ignored. Set it to non-nil to enable evaluation of elisp formulas in tables.
+Warning: Only set this in trusted files! I am not responsible for any issues, damages, or bug reports caused by using this feature, and will not handle related issues.")
+(put 'grid-table-allow-elisp 'risky-local-variable t)
+
 (defvar-local grid-table--data-source nil
   "Buffer-local variable to hold the current data source instance.")
 


### PR DESCRIPTION
add risky local variable `grid-table-allow-elisp`.
if this is nil (default), elisp formulas in tables will not be evaluated.